### PR TITLE
[홈 화면 - 02] 디자인 모듈 패키지명 변경

### DIFF
--- a/design/src/androidTest/java/com/ftw/hometerview/design/ExampleInstrumentedTest.kt
+++ b/design/src/androidTest/java/com/ftw/hometerview/design/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
-package kr.co.remember.design
+package com.ftw.hometerview.design
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -19,6 +17,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("kr.co.remember.design.test", appContext.packageName)
+        assertEquals("com.ftw.hometerview.design.test", appContext.packageName)
     }
 }

--- a/design/src/main/AndroidManifest.xml
+++ b/design/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="kr.co.remember.design"
-    >
+<manifest package="com.ftw.hometerview.design">
 
 </manifest>

--- a/design/src/main/java/com/ftw/hometerview/design/Button.kt
+++ b/design/src/main/java/com/ftw/hometerview/design/Button.kt
@@ -1,4 +1,4 @@
-package kr.co.remember.design
+package com.ftw.hometerview.design
 
 import android.content.Context
 import android.graphics.drawable.Drawable

--- a/design/src/test/java/com/ftw/hometerview/design/ExampleUnitTest.kt
+++ b/design/src/test/java/com/ftw/hometerview/design/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
-package kr.co.remember.design
+package com.ftw.hometerview.design
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).


### PR DESCRIPTION
### 0. 화면 이미지
* N/A

### 1. 개요
- design 모듈의 패키지명 변경
  - as-is: kr.co.rememberapp
  - to-be: com.ftw.hometerview

### 2. 작업사항
- design 모듈을 복붙한 게 아니고 새로 만들었는데, 패키지명이 이렇게 들어가 버렸더라고...? 🥲 그래서 패키지명만 변경한 PR 입니당...

### 3. 변경로직
* N/A

### 4. 기타
* N/A