### PR TITLE
6/collapsed toolbar

### DIFF
--- a/app/src/main/java/com/ftw/hometerview/ui/buildingreview/BuildingReviewActivity.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/buildingreview/BuildingReviewActivity.kt
@@ -5,6 +5,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import android.util.Log
+import android.util.TypedValue
+import android.view.Gravity.CENTER
+import android.view.Gravity.LEFT
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Lifecycle
@@ -18,6 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
+import java.lang.Math.abs
 
 @AndroidEntryPoint
 class BuildingReviewActivity : AppCompatActivity() {
@@ -29,6 +33,7 @@ class BuildingReviewActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityBuildingReviewBinding
     private val adapter = DataBindingRecyclerAdapter()
+    private var appBarExpanded = true
 
     @Inject
     lateinit var viewModel: BuildingReviewViewModel
@@ -44,6 +49,19 @@ class BuildingReviewActivity : AppCompatActivity() {
 
         initList()
         observe()
+
+        binding.appBar.addOnOffsetChangedListener { appBarLayout, verticalOffset ->
+
+            //  Vertical offset == 0 indicates appBar is fully expanded.
+            if (abs(verticalOffset) > 200) {
+                binding.toolbarBuildingNameTextView.gravity = CENTER
+                binding.toolbarBuildingNameTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,resources.getDimensionPixelSize(R.dimen.sp_size_14).toFloat())
+            } else {
+                appBarExpanded = true
+                binding.toolbarBuildingNameTextView.gravity = LEFT
+                binding.toolbarBuildingNameTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,resources.getDimensionPixelSize(R.dimen.sp_size_24).toFloat())
+            }
+        }
     }
 
     private fun initList() {

--- a/app/src/main/java/com/ftw/hometerview/ui/buildingreview/BuildingReviewActivity.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/buildingreview/BuildingReviewActivity.kt
@@ -33,7 +33,6 @@ class BuildingReviewActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityBuildingReviewBinding
     private val adapter = DataBindingRecyclerAdapter()
-    private var appBarExpanded = true
 
     @Inject
     lateinit var viewModel: BuildingReviewViewModel
@@ -57,7 +56,6 @@ class BuildingReviewActivity : AppCompatActivity() {
                 binding.toolbarBuildingNameTextView.gravity = CENTER
                 binding.toolbarBuildingNameTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,resources.getDimensionPixelSize(R.dimen.sp_size_14).toFloat())
             } else {
-                appBarExpanded = true
                 binding.toolbarBuildingNameTextView.gravity = LEFT
                 binding.toolbarBuildingNameTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,resources.getDimensionPixelSize(R.dimen.sp_size_24).toFloat())
             }

--- a/app/src/main/java/com/ftw/hometerview/ui/buildingreview/BuildingReviewActivity.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/buildingreview/BuildingReviewActivity.kt
@@ -52,7 +52,7 @@ class BuildingReviewActivity : AppCompatActivity() {
         binding.appBar.addOnOffsetChangedListener { appBarLayout, verticalOffset ->
 
             //  Vertical offset == 0 indicates appBar is fully expanded.
-            if (abs(verticalOffset) > 200) {
+            if (abs(verticalOffset) == appBarLayout.totalScrollRange) {
                 binding.toolbarBuildingNameTextView.gravity = CENTER
                 binding.toolbarBuildingNameTextView.setTextSize(TypedValue.COMPLEX_UNIT_PX,resources.getDimensionPixelSize(R.dimen.sp_size_14).toFloat())
             } else {

--- a/app/src/main/res/drawable/ic_baseline_chevron_left_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_chevron_left_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M15.41,7.41L14,6l-6,6 6,6 1.41,-1.41L10.83,12z"/>
+</vector>

--- a/app/src/main/res/layout/activity_building_review.xml
+++ b/app/src/main/res/layout/activity_building_review.xml
@@ -16,6 +16,7 @@
         >
 
         <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/app_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             >
@@ -26,25 +27,34 @@
                 app:layout_scrollFlags="scroll|exitUntilCollapsed"
                 >
 
-<!--                <ImageView-->
-<!--                    android:layout_width="match_parent"-->
-<!--                    android:layout_height="200dp"-->
-<!--                    app:srcCompat="@drawable/image_map_sample"-->
-<!--                    android:fitsSystemWindows="true"-->
-<!--                    app:layout_constraintTop_toTopOf="parent"-->
-<!--                    />-->
+                <!--                <ImageView-->
+                <!--                    android:layout_width="match_parent"-->
+                <!--                    android:layout_height="200dp"-->
+                <!--                    app:srcCompat="@drawable/image_map_sample"-->
+                <!--                    android:fitsSystemWindows="true"-->
+                <!--                    app:layout_constraintTop_toTopOf="parent"-->
+                <!--                    />-->
 
                 <View
                     android:layout_width="match_parent"
                     android:layout_height="200dp"
                     android:background="@color/white"
                     />
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_baseline_chevron_left_24"
+                    app:layout_collapseMode="pin"
+                    android:layout_marginTop="@dimen/dp_size_16"
+                    android:layout_marginStart="@dimen/dp_size_16"/>
 
                 <com.google.android.material.appbar.MaterialToolbar
                     android:layout_width="match_parent"
                     android:layout_height="?attr/actionBarSize"
                     app:layout_collapseMode="pin"
                     app:titleTextColor="@color/gray_900"
+                    android:layout_gravity="bottom"
+                    app:contentInsetStart="0dp"
                     >
 
                     <androidx.constraintlayout.widget.ConstraintLayout
@@ -52,41 +62,39 @@
                         android:layout_height="match_parent"
                         >
 
-<!--                        <androidx.appcompat.widget.AppCompatImageButton-->
-<!--                            android:id="@+id/back_image_view"-->
-<!--                            android:layout_width="wrap_content"-->
-<!--                            android:layout_height="wrap_content"-->
-<!--                            app:srcCompat="@drawable/icon_back"-->
-<!--                            app:layout_constraintTop_toTopOf="parent"-->
-<!--                            app:layout_constraintBottom_toBottomOf="parent"-->
-<!--                            app:layout_constraintStart_toStartOf="parent"-->
-<!--                            />-->
+                        <!--                        <androidx.appcompat.widget.AppCompatImageButton-->
+                        <!--                            android:id="@+id/back_image_view"-->
+                        <!--                            android:layout_width="wrap_content"-->
+                        <!--                            android:layout_height="wrap_content"-->
+                        <!--                            app:srcCompat="@drawable/icon_back"-->
+                        <!--                            app:layout_constraintTop_toTopOf="parent"-->
+                        <!--                            app:layout_constraintBottom_toBottomOf="parent"-->
+                        <!--                            app:layout_constraintStart_toStartOf="parent"-->
+                        <!--                            />-->
 
                         <TextView
                             android:id="@+id/toolbar_building_name_text_view"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/dp_size_16"
                             android:layout_marginHorizontal="@dimen/sp_size_14"
-                            android:text="@{viewModel.building.name}"
-                            android:textSize="@dimen/sp_size_24"
-                            android:textColor="@color/gray_900"
                             android:fontFamily="@font/pretendard_bold"
-                            app:layout_constraintTop_toTopOf="parent"
+                            android:text="@{viewModel.building.name}"
+                            android:textColor="@color/gray_900"
+                            android:textSize="@dimen/sp_size_24"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintEnd_toStartOf="@id/toolbar_favorite_image_view"
-                            />
+                            app:layout_constraintTop_toTopOf="parent" />
 
                         <ImageView
                             android:id="@+id/toolbar_favorite_image_view"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/dp_size_16"
                             android:layout_marginEnd="@dimen/sp_size_14"
-                            app:srcCompat="@drawable/icon_heart"
-                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toEndOf="parent"
-                            />
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:srcCompat="@drawable/icon_heart" />
 
                     </androidx.constraintlayout.widget.ConstraintLayout>
                 </com.google.android.material.appbar.MaterialToolbar>
@@ -105,45 +113,45 @@
                 android:layout_height="match_parent"
                 >
 
-                <TextView
-                    android:id="@+id/building_name_text_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/dp_size_16"
-                    android:layout_marginHorizontal="@dimen/sp_size_14"
-                    android:text="@{viewModel.building.name}"
-                    android:textSize="@dimen/sp_size_24"
-                    android:textColor="@color/gray_900"
-                    android:fontFamily="@font/pretendard_bold"
-                    app:layout_constraintTop_toTopOf="parent"
-                    />
+                <!--                <TextView-->
+                <!--                    android:id="@+id/building_name_text_view"-->
+                <!--                    android:layout_width="match_parent"-->
+                <!--                    android:layout_height="wrap_content"-->
+                <!--                    android:layout_marginTop="@dimen/dp_size_16"-->
+                <!--                    android:layout_marginHorizontal="@dimen/sp_size_14"-->
+                <!--                    android:text="@{viewModel.building.name}"-->
+                <!--                    android:textSize="@dimen/sp_size_24"-->
+                <!--                    android:textColor="@color/gray_900"-->
+                <!--                    android:fontFamily="@font/pretendard_bold"-->
+                <!--                    app:layout_constraintTop_toTopOf="parent"-->
+                <!--                    />-->
 
-                <ImageView
-                    android:id="@+id/img_favorite"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/dp_size_16"
-                    android:layout_marginEnd="@dimen/sp_size_14"
-                    app:srcCompat="@drawable/icon_heart"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    />
+                <!--                <ImageView-->
+                <!--                    android:id="@+id/img_favorite"-->
+                <!--                    android:layout_width="wrap_content"-->
+                <!--                    android:layout_height="wrap_content"-->
+                <!--                    android:layout_marginTop="@dimen/dp_size_16"-->
+                <!--                    android:layout_marginEnd="@dimen/sp_size_14"-->
+                <!--                    app:srcCompat="@drawable/icon_heart"-->
+                <!--                    app:layout_constraintTop_toTopOf="parent"-->
+                <!--                    app:layout_constraintEnd_toEndOf="parent"-->
+                <!--                    />-->
 
                 <TextView
                     android:id="@+id/address_text_view"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/dp_size_16"
                     android:layout_marginHorizontal="@dimen/dp_size_14"
+                    android:layout_marginTop="@dimen/dp_size_16"
                     android:drawablePadding="@dimen/dp_size_6"
-                    android:text="@{viewModel.building.address.addressWithLoadName}"
-                    android:textSize="@dimen/sp_size_14"
-                    android:textColor="@color/gray_800"
                     android:fontFamily="@font/pretendard_regular"
+                    android:text="@{viewModel.building.address.addressWithLoadName}"
+                    android:textColor="@color/gray_800"
+                    android:textSize="@dimen/sp_size_14"
                     app:drawableStartCompat="@drawable/icon_discovery"
                     app:drawableTint="@color/gray_400"
-                    app:layout_constraintTop_toBottomOf="@id/building_name_text_view"
-                    />
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:layout_editor_absoluteX="14dp" />
 
                 <TextView
                     android:id="@+id/building_type_text_view"


### PR DESCRIPTION
### 0. 화면 이미지
https://user-images.githubusercontent.com/54509842/183379162-d1854cfe-6ce6-49d8-bde6-299505de1819.mp4


### 1. 개요
스크롤롤링에 의해 바뀌는 툴바 구현

### 2. 작업사항
<img src="https://user-images.githubusercontent.com/54509842/183379263-4ab5fe30-f43e-4de3-a5b8-d516bc8f8426.jpeg" width="30%"></img>

초록색 박스의 내용을 스크롤해서 아래로 내려가면 발간색 박스로 이동해서 pin 되게 구현했습니다. 
빨간색 박스의 pin 기점은 (엄밀히 말하면 타이틀 텍스트가 바귀는 시점) 파란색 박스의 높이가 일정 수치 미만일 때를 식별하는 리스너를 구현했습니다.

작동 자체는 잘 되지만, 석연찮은 부분이 하나 있습니다. 

<img src="https://user-images.githubusercontent.com/54509842/183380273-6c6d5f50-e63e-48b6-b42e-19984096e460.jpeg" width="30%"></img>

뒤로가기 버튼이 초록색 박스의 마진을 알 수 없어서 대략적으로 수치를 부여했다는 점입니다. 이를 보완해야할 필요성이 있습니다.

### 3. 변경로직

### 4. 기타
아 그리고, MaterialToolBar를 사용하면서 왼쪽에아이콘 배치를 위한 여백이 생성되어있는데 이를 없애 줘야 스크롤해서 위에 고정된 타이틀이 제대로 가운데를 찾아갈 수 있습니다. 