### PR TITLE
[Flipper] Flipper 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,14 @@ dependencies {
 
     implementation "com.kakao.sdk:v2-user:$kakao_version"
 
+    debugImplementation "com.facebook.flipper:flipper:$flipper_version"
+    debugImplementation "com.facebook.soloader:soloader:$soloader_version"
+    debugImplementation "com.facebook.flipper:flipper-network-plugin:$flipper_version"
+    debugImplementation "com.facebook.flipper:flipper-retrofit2-protobuf-plugin:$flipper_retrofit2_protobuf_plugin_version"
+    releaseImplementation "com.facebook.flipper:flipper-noop:$flipper_version"
+    releaseImplementation "com.github.theGlenn:flipper-android-no-op:$flipper_android_no_op_version"
+
+
     testImplementation "junit:junit:$junit_version"
     androidTestImplementation "androidx.test.ext:junit:$android_junit_version"
     androidTestImplementation "androidx.test.espresso:espresso-core:$android_espresso_core_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,12 @@
             </intent-filter>
         </activity>
 
+        <!-- Flipper to diagnose integration issues and other problems -->
+        <activity
+            android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
+            android:exported="true"
+            />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ftw/hometerview/config/HometerviewApplication.kt
+++ b/app/src/main/java/com/ftw/hometerview/config/HometerviewApplication.kt
@@ -11,9 +11,13 @@ import com.ftw.hometerview.BuildConfig
 import com.ftw.hometerview.R
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
 class HometerviewApplication : Application() {
+
+    @Inject
+    lateinit var networkFlipperPlugin: NetworkFlipperPlugin
 
     override fun onCreate() {
         super.onCreate()
@@ -30,8 +34,13 @@ class HometerviewApplication : Application() {
 
         if (BuildConfig.DEBUG && FlipperUtils.shouldEnableFlipper(this)) {
             AndroidFlipperClient.getInstance(this).apply {
-                addPlugin(InspectorFlipperPlugin(this@HometerviewApplication, DescriptorMapping.withDefaults()))
-                addPlugin(NetworkFlipperPlugin())
+                addPlugin(
+                    InspectorFlipperPlugin(
+                        this@HometerviewApplication,
+                        DescriptorMapping.withDefaults()
+                    )
+                )
+                addPlugin(networkFlipperPlugin)
             }.run { start() }
         }
     }

--- a/app/src/main/java/com/ftw/hometerview/config/HometerviewApplication.kt
+++ b/app/src/main/java/com/ftw/hometerview/config/HometerviewApplication.kt
@@ -1,6 +1,13 @@
 package com.ftw.hometerview.config
 
 import android.app.Application
+import com.facebook.flipper.android.AndroidFlipperClient
+import com.facebook.flipper.android.utils.FlipperUtils
+import com.facebook.flipper.plugins.inspector.DescriptorMapping
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
+import com.facebook.soloader.SoLoader
+import com.ftw.hometerview.BuildConfig
 import com.ftw.hometerview.R
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
@@ -10,6 +17,22 @@ class HometerviewApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        initializeKakaoSdk()
+        initializeFlipper()
+    }
+
+    private fun initializeKakaoSdk() {
         KakaoSdk.init(this, getString(R.string.kakao_api_key))
+    }
+
+    private fun initializeFlipper() {
+        SoLoader.init(this, false)
+
+        if (BuildConfig.DEBUG && FlipperUtils.shouldEnableFlipper(this)) {
+            AndroidFlipperClient.getInstance(this).apply {
+                addPlugin(InspectorFlipperPlugin(this@HometerviewApplication, DescriptorMapping.withDefaults()))
+                addPlugin(NetworkFlipperPlugin())
+            }.run { start() }
+        }
     }
 }

--- a/app/src/main/java/com/ftw/hometerview/di/api/NetworkModule.kt
+++ b/app/src/main/java/com/ftw/hometerview/di/api/NetworkModule.kt
@@ -1,5 +1,7 @@
 package com.ftw.hometerview.di.api
 
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,7 +18,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 class NetworkModule {
 
     companion object {
-        private const val BASE_URL = ""
+        private const val BASE_URL = "https://api.github.com"
     }
 
     @Provides
@@ -42,13 +44,27 @@ class NetworkModule {
 
     @Provides
     @Singleton
+    fun provideNetworkFlipperPlugin(): NetworkFlipperPlugin {
+        return NetworkFlipperPlugin()
+    }
+
+    @Provides
+    @Singleton
+    fun provideFlipperInterceptor(networkFlipperPlugin: NetworkFlipperPlugin): FlipperOkhttpInterceptor {
+        return FlipperOkhttpInterceptor(networkFlipperPlugin)
+    }
+
+    @Provides
+    @Singleton
     fun provideOkHttpClient(
         headerInterceptor: Interceptor,
-        loggingInterceptor: HttpLoggingInterceptor
+        loggingInterceptor: HttpLoggingInterceptor,
+        networkFlipperOkhttpInterceptor: FlipperOkhttpInterceptor
     ): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(headerInterceptor)
             .addInterceptor(loggingInterceptor)
+            .addNetworkInterceptor(networkFlipperOkhttpInterceptor)
             .build()
     }
 

--- a/data/src/main/java/com/ftw/data/datasource/LoginDataSource.kt
+++ b/data/src/main/java/com/ftw/data/datasource/LoginDataSource.kt
@@ -1,5 +1,5 @@
 package com.ftw.data.datasource
 
 interface LoginDataSource {
-    fun login(token: String): Result<String>
+    suspend fun login(token: String): Result<String>
 }

--- a/data/src/main/java/com/ftw/data/network/datasource/LoginRemoteDataSource.kt
+++ b/data/src/main/java/com/ftw/data/network/datasource/LoginRemoteDataSource.kt
@@ -3,8 +3,12 @@ package com.ftw.data.network.datasource
 import com.ftw.data.datasource.LoginDataSource
 import com.ftw.data.remote.api.LoginAPI
 
-class LoginRemoteDataSource(api: LoginAPI) : LoginDataSource {
-    override fun login(token: String): Result<String> {
-        return Result.success("")
+class LoginRemoteDataSource(private val api: LoginAPI) : LoginDataSource {
+    override suspend fun login(token: String): Result<String> {
+        return api.searchUser("hayley", 1, 100)
+            .items
+            .firstOrNull()
+            ?.let { Result.success(it.login) }
+            ?: Result.success("failed")
     }
 }

--- a/data/src/main/java/com/ftw/data/remote/api/LoginAPI.kt
+++ b/data/src/main/java/com/ftw/data/remote/api/LoginAPI.kt
@@ -1,4 +1,14 @@
 package com.ftw.data.remote.api
 
+import com.ftw.data.remote.response.SearchUserResponseData
+import retrofit2.http.GET
+import retrofit2.http.Query
+
 interface LoginAPI {
+    @GET("/search/users")
+    suspend fun searchUser(
+        @Query("q") keyword: String,
+        @Query("page") page: Int,
+        @Query("per_page") perPage: Int
+    ): SearchUserResponseData
 }

--- a/data/src/main/java/com/ftw/data/remote/response/Item.kt
+++ b/data/src/main/java/com/ftw/data/remote/response/Item.kt
@@ -1,0 +1,23 @@
+package com.ftw.data.remote.response
+
+data class Item(
+    val avatar_url: String,
+    val events_url: String,
+    val followers_url: String,
+    val following_url: String,
+    val gists_url: String,
+    val gravatar_id: String,
+    val html_url: String,
+    val id: Int,
+    val login: String,
+    val node_id: String,
+    val organizations_url: String,
+    val received_events_url: String,
+    val repos_url: String,
+    val score: Double,
+    val site_admin: Boolean,
+    val starred_url: String,
+    val subscriptions_url: String,
+    val type: String,
+    val url: String
+)

--- a/data/src/main/java/com/ftw/data/remote/response/SearchUserResponseData.kt
+++ b/data/src/main/java/com/ftw/data/remote/response/SearchUserResponseData.kt
@@ -1,0 +1,7 @@
+package com.ftw.data.remote.response
+
+data class SearchUserResponseData(
+    val incomplete_results: Boolean,
+    val items: List<Item>,
+    val total_count: Int
+)

--- a/data/src/main/java/com/ftw/data/repository/login/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/ftw/data/repository/login/LoginRepositoryImpl.kt
@@ -4,8 +4,8 @@ import com.ftw.data.datasource.LoginDataSource
 import com.ftw.domain.repository.login.LoginRepository
 
 class LoginRepositoryImpl(private val loginDataSource: LoginDataSource) : LoginRepository {
-    override fun login(token: String): Result<String> {
+    override suspend fun login(token: String): Result<String> {
         // TODO: token 으로 login 하는 로직 추가
-        return Result.success("temporary token")
+        return loginDataSource.login("temporary token")
     }
 }

--- a/domain/src/main/java/com/ftw/domain/repository/login/LoginRepository.kt
+++ b/domain/src/main/java/com/ftw/domain/repository/login/LoginRepository.kt
@@ -1,5 +1,5 @@
 package com.ftw.domain.repository.login
 
 interface LoginRepository {
-    fun login(token: String): Result<String>
+    suspend fun login(token: String): Result<String>
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -20,6 +20,11 @@ ext {
     gson_version = '2.9.0'
     kakao_version = '2.11.0'
 
+    flipper_version = '0.156.0'
+    soloader_version = '0.10.4'
+    flipper_android_no_op_version = '0.9.0'
+    flipper_retrofit2_protobuf_plugin_version = '0.91.2'
+
     junit_version = '4.13.2'
     android_junit_version = '1.1.3'
     android_espresso_core_version = '3.4.0'


### PR DESCRIPTION
### 1. 개요
API 요청/응답 값을 편하게 보기 위한 툴 추가

### 2. 작업사항
* Flipper 라이브러리 초기화 로직 추가
  * 네트워크 통신 뿐만 아니라 SharedPreferences 에 저장된 값을 확인/수정하는 plugin, UI 레이아웃 hierarchy plugin 등을 추가할 수 있음

### 3. 변경로직
* `HometerviewApplication` 에 Flipper 초기화 로직 추가

### 4. 스크린샷
<img width="1920" alt="0810_flipper" src="https://user-images.githubusercontent.com/43338377/183911507-7605519d-e7d4-412e-8ce2-fd5d41a45884.png">

### 5. 참고링크
* [Flipper 홈페이지](https://fbflipper.com/) : 해당 링크에서 맥용 Flipper 프로그램 설치 필요
* [Flipper 개발문서](https://fbflipper.com/docs/getting-started/android-native/)

### 6. 기타
* N/A
