### PR TITLE
[집터뷰 작성 - 02] 첫 번째 스텝의 거주층 선택 화면 구현

### DIFF
--- a/app/src/main/java/com/ftw/hometerview/di/ui/CreateReviewFragmentViewModelModule.kt
+++ b/app/src/main/java/com/ftw/hometerview/di/ui/CreateReviewFragmentViewModelModule.kt
@@ -3,6 +3,7 @@ package com.ftw.hometerview.di.ui
 import com.ftw.domain.usecase.address.GetAddressUseCase
 import com.ftw.hometerview.dispatcher.Dispatcher
 import com.ftw.hometerview.ui.review.first.CreateReviewFirstStepViewModel
+import com.ftw.hometerview.ui.review.second.CreateReviewSecondStepViewModel
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,5 +24,11 @@ class CreateReviewFragmentViewModelModule {
             dispatcher,
             getAddressUseCase
         )
+    }
+
+    @Provides
+    @FragmentScoped
+    fun provideCreateReviewSecondStepViewModel(): CreateReviewSecondStepViewModel {
+        return CreateReviewSecondStepViewModel()
     }
 }

--- a/app/src/main/java/com/ftw/hometerview/ui/review/CreateReviewActivity.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/review/CreateReviewActivity.kt
@@ -7,12 +7,14 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.ftw.hometerview.R
 import com.ftw.hometerview.databinding.ActivityCreateReviewBinding
+import com.ftw.hometerview.extension.addFragment
 import com.ftw.hometerview.extension.replaceFragment
 import com.ftw.hometerview.ui.review.first.CreateReviewFirstStepFragment
+import com.ftw.hometerview.ui.review.second.CreateReviewSecondStepFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class CreateReviewActivity : AppCompatActivity() {
+class CreateReviewActivity : AppCompatActivity(), CreateReviewFirstStepFragment.Listener {
     companion object {
         fun newIntent(context: Context): Intent = Intent(context, CreateReviewActivity::class.java)
     }
@@ -20,6 +22,10 @@ class CreateReviewActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         DataBindingUtil.setContentView<ActivityCreateReviewBinding>(this, R.layout.activity_create_review)
-        replaceFragment(R.id.frame_layout, CreateReviewFirstStepFragment.newInstance(), false)
+        replaceFragment(R.id.fragment_container_view, CreateReviewFirstStepFragment.newInstance(), false)
+    }
+
+    override fun onClickAddressFromFirstStep(address: String) {
+        addFragment(R.id.fragment_container_view, CreateReviewSecondStepFragment.newInstance(address), true)
     }
 }

--- a/app/src/main/java/com/ftw/hometerview/ui/review/second/CreateReviewSecondStepFragment.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/review/second/CreateReviewSecondStepFragment.kt
@@ -1,0 +1,92 @@
+package com.ftw.hometerview.ui.review.second
+
+import android.os.Bundle
+import android.os.Parcelable
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.ftw.hometerview.R
+import com.ftw.hometerview.databinding.FragmentCreateReviewSecondStepBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class CreateReviewSecondStepFragment : Fragment() {
+    companion object {
+        private const val ARGUMENT_KEY = "CREATE_REVIEW_SECOND_STEP_ARGUMENT_KEY"
+        fun newInstance(address: String): CreateReviewSecondStepFragment {
+            return CreateReviewSecondStepFragment().apply {
+                arguments = bundleOf(ARGUMENT_KEY to Argument(address))
+            }
+        }
+    }
+
+    private var _binding: FragmentCreateReviewSecondStepBinding? = null
+    private val binding get() = _binding!!
+
+    @Inject
+    lateinit var viewModel: CreateReviewSecondStepViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = DataBindingUtil.inflate<FragmentCreateReviewSecondStepBinding?>(
+            inflater,
+            R.layout.fragment_create_review_second_step,
+            container,
+            false
+        ).apply {
+            this.viewModel = this@CreateReviewSecondStepFragment.viewModel
+        }
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        arguments?.getParcelable<Argument>(ARGUMENT_KEY)?.also { argument ->
+            viewModel.setAddress(argument.address)
+        } ?: let {
+            activity?.onBackPressed()
+            return
+        }
+
+        observe()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun observe() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.event.collect { event ->
+                    when (event) {
+                        CreateReviewSecondStepViewModel.Event.Nothing -> {}
+                        CreateReviewSecondStepViewModel.Event.OnClickResidentialFloor -> showSelectResidentialFloorBottomSheet()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun showSelectResidentialFloorBottomSheet() {
+        // TODO 거주층 선택 반팝업 노출
+        Log.d("SecondStep", "showSelectResidentialFloorBottomSheet: ")
+    }
+
+    @Parcelize
+    data class Argument(val address: String) : Parcelable
+}

--- a/app/src/main/java/com/ftw/hometerview/ui/review/second/CreateReviewSecondStepViewModel.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/review/second/CreateReviewSecondStepViewModel.kt
@@ -1,0 +1,33 @@
+package com.ftw.hometerview.ui.review.second
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class CreateReviewSecondStepViewModel {
+
+    sealed class Event {
+        object Nothing : Event()
+        object OnClickResidentialFloor : Event()
+    }
+
+    private val _event: MutableStateFlow<Event> = MutableStateFlow(Event.Nothing)
+    val event: StateFlow<Event> = _event.asStateFlow()
+
+    private val _address: MutableStateFlow<String> = MutableStateFlow("")
+    val address: StateFlow<String> = _address.asStateFlow()
+
+    val residentialFloor: MutableStateFlow<String> = MutableStateFlow("")
+
+    fun setAddress(address: String) {
+        _address.value = address
+    }
+
+    fun setResidentialFloor(residentialFloor: String) {
+        this.residentialFloor.value = residentialFloor
+    }
+
+    fun onClickResidentialFloor() {
+        _event.value = Event.OnClickResidentialFloor
+    }
+}

--- a/app/src/main/res/drawable/icon_next.xml
+++ b/app/src/main/res/drawable/icon_next.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="30dp"
+    android:height="30dp"
+    android:viewportWidth="30"
+    android:viewportHeight="30">
+  <path
+      android:pathData="M14.293,19.718C14.683,20.108 15.317,20.108 15.707,19.718L22.071,13.354C22.462,12.963 22.462,12.33 22.071,11.939C21.681,11.549 21.047,11.549 20.657,11.939L15,17.596L9.343,11.939C8.953,11.549 8.319,11.549 7.929,11.939C7.538,12.33 7.538,12.963 7.929,13.354L14.293,19.718Z"
+      android:fillColor="#8D94A0"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/activity_create_review.xml
+++ b/app/src/main/res/layout/activity_create_review.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
-    <FrameLayout
-        android:id="@+id/frame_layout"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         />

--- a/app/src/main/res/layout/fragment_create_review_second_step.xml
+++ b/app/src/main/res/layout/fragment_create_review_second_step.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+    <data>
+        <variable
+            name="viewModel"
+            type="com.ftw.hometerview.ui.review.second.CreateReviewSecondStepViewModel"
+            />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        >
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/progress_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:progress="33"
+            android:max="100"
+            android:indeterminate="false"
+            app:trackThickness="@dimen/dp_size_4"
+            app:trackColor="@color/gray_100"
+            app:indicatorColor="@color/blue_300"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:contentInsetStart="0dp"
+            app:layout_constraintTop_toBottomOf="@id/progress_bar"
+            >
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                >
+
+                <ImageView
+                    android:id="@+id/toolbar_back_image_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/dp_size_14"
+                    app:srcCompat="@drawable/icon_back"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    />
+
+                <TextView
+                    android:id="@+id/toolbar_title_text_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/create_review_title"
+                    android:textSize="@dimen/sp_size_16"
+                    android:textColor="@color/gray_900"
+                    android:fontFamily="@font/pretendard_semibold"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/toolbar_border"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+
+                <TextView
+                    android:id="@+id/toolbar_cancel_text_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:paddingHorizontal="@dimen/dp_size_12"
+                    android:gravity="center"
+                    android:text="@string/cancel"
+                    android:textSize="@dimen/sp_size_14"
+                    android:textColor="@color/black"
+                    android:fontFamily="@font/pretendard_regular"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toTopOf="@id/toolbar_border"
+                    />
+
+                <View
+                    android:id="@+id/toolbar_border"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/dp_size_1"
+                    android:background="@color/gray_200"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.appcompat.widget.Toolbar>
+
+        <TextView
+            android:id="@+id/address_title_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/dp_size_24"
+            android:layout_marginStart="@dimen/dp_size_14"
+            android:fontFamily="@font/pretendard_regular"
+            android:text="@string/address"
+            android:textSize="@dimen/sp_size_14"
+            android:textColor="@color/gray_800"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:layout_constraintStart_toStartOf="parent"
+            />
+
+        <TextView
+            android:id="@+id/address_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/dp_size_8"
+            android:layout_marginHorizontal="@dimen/dp_size_14"
+            android:fontFamily="@font/pretendard_regular"
+            android:text="@{viewModel.address}"
+            android:textSize="@dimen/sp_size_14"
+            android:textColor="@color/gray_900"
+            app:layout_constraintTop_toBottomOf="@id/address_title_text_view"
+            app:layout_constraintStart_toStartOf="parent"
+            />
+
+        <TextView
+            android:id="@+id/floor_title_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/dp_size_24"
+            android:layout_marginStart="@dimen/dp_size_14"
+            android:fontFamily="@font/pretendard_regular"
+            android:text="@string/residential_floor"
+            android:textSize="@dimen/sp_size_14"
+            android:textColor="@color/gray_800"
+            app:layout_constraintTop_toBottomOf="@id/address_text_view"
+            app:layout_constraintStart_toStartOf="parent"
+            />
+
+        <EditText
+            android:id="@+id/residential_floor_edit_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/dp_size_8"
+            android:layout_marginHorizontal="@dimen/dp_size_14"
+            android:editable="false"
+            android:inputType="none"
+            android:paddingVertical="@dimen/dp_size_10"
+            android:paddingStart="@dimen/dp_size_16"
+            android:paddingEnd="@dimen/dp_size_10"
+            android:background="@drawable/bg_transparent_border_gray_300_radius_8"
+            android:onClick="@{() -> viewModel.onClickResidentialFloor()}"
+            android:drawableEnd="@drawable/icon_next"
+            android:drawableTint="@color/gray_500"
+            android:fontFamily="@font/pretendard_regular"
+            android:hint="@string/create_review_residential_floor_hint"
+            android:text="@={viewModel.residentialFloor}"
+            android:textSize="@dimen/sp_size_14"
+            android:textColor="@color/gray_900"
+            android:textColorHint="@color/gray_400"
+            app:layout_constraintTop_toBottomOf="@id/floor_title_text_view"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="create_review_address_tip_description3_message">예) 분당 주공, 연수동 주공3차</string>
     <string name="create_review_address_tip_description4_title">사서함명 + 번호</string>
     <string name="create_review_address_tip_description4_message">예) 분당우체국사서함 1~100</string>
+    <string name="create_review_residential_floor_hint">거주층을 선택해 주세요</string>
 
     <string name="get_token_error">저장된 토큰이 없습니다.</string>
     <string name="guide_text1">나랑 같은 지역으로 출근하는 사람들은 어디에 살고있을까?</string>


### PR DESCRIPTION
### 1. 개요
집터뷰 작성 첫 번째 단계 화면 구현

### 2. 작업사항
* 화면 진입 시 이전에 선택한 주소 노출
* '거주층' 인풋 필드 클릭 시 '거주층 선택 반팝업' 은 새로운 PR 로 요청할 예정

### 3. 변경로직
* N/A

### 4. 스크린샷
| 영상 | 스크린샷 |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/43338377/184579887-7423436c-24ff-49fd-8a54-89d6c557b836.mp4" width="300"> | <img src="https://user-images.githubusercontent.com/43338377/184579896-204bc72a-ea59-462c-bc42-83472dc01406.png" width="300">

### 5. 참고링크
- [디자인](https://www.figma.com/file/VBtuKLaxlF1ZaKEXCh505b/hometerview?node-id=459%3A18338)

### 6. 기타
* N/A