### PR TITLE
[마이페이지 화면 - 06] 로그아웃 화면

### DIFF
--- a/app/src/main/java/com/ftw/hometerview/ui/dialog/LogoutDialog.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/dialog/LogoutDialog.kt
@@ -1,0 +1,37 @@
+package com.ftw.hometerview.ui.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.ftw.hometerview.databinding.DialogLogoutBinding
+
+class LogoutDialog(val logout: () -> Unit) : DialogFragment() {
+    private var _binding: DialogLogoutBinding? = null
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = DialogLogoutBinding.inflate(inflater, container, false)
+        val view = binding.root
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        binding.logoutSelect.setOnClickListener {
+            logout()
+        }
+        binding.logoutCancle.setOnClickListener {
+            dismiss()
+        }
+        return view
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/ftw/hometerview/ui/dialog/LogoutDialog.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/dialog/LogoutDialog.kt
@@ -7,11 +7,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
+import com.ftw.domain.entity.Floor
 import com.ftw.hometerview.databinding.DialogLogoutBinding
 
-class LogoutDialog(val logout: () -> Unit) : DialogFragment() {
+class LogoutDialog() : DialogFragment() {
     private var _binding: DialogLogoutBinding? = null
     private val binding get() = _binding!!
+
+    interface Listener {
+        fun onClickLogoutFromLogoutDialog()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -22,7 +27,7 @@ class LogoutDialog(val logout: () -> Unit) : DialogFragment() {
         val view = binding.root
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         binding.logoutSelect.setOnClickListener {
-            logout()
+            (parentFragment as? Listener)?.onClickLogoutFromLogoutDialog()
         }
         binding.logoutCancle.setOnClickListener {
             dismiss()

--- a/app/src/main/java/com/ftw/hometerview/ui/dialog/LogoutDialog.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/dialog/LogoutDialog.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
-import com.ftw.domain.entity.Floor
 import com.ftw.hometerview.databinding.DialogLogoutBinding
 
 class LogoutDialog() : DialogFragment() {

--- a/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageFragment.kt
@@ -18,6 +18,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.ftw.hometerview.R
 import com.ftw.hometerview.databinding.FragmentMyPageBinding
+import com.ftw.hometerview.ui.dialog.LogoutDialog
+import com.ftw.hometerview.ui.login.LoginActivity
 import com.ftw.hometerview.ui.manageaccount.ManageAccountActivity
 import com.ftw.hometerview.ui.updatenickname.UpdateNicknameActivity
 import com.ftw.hometerview.ui.myreviews.MyReviewsActivity
@@ -77,6 +79,7 @@ class MyPageFragment : Fragment() {
                         is MyPageViewModel.Event.onClickUpdateNickname -> updateNicknameActivity(event.nickname)
                         MyPageViewModel.Event.onClickWrittenReview -> writtenReviewActivity()
                         MyPageViewModel.Event.onClickManageAccount -> manageAccountActivity()
+                        MyPageViewModel.Event.onClickLogout -> onClickLogoutDialog()
                     }
                 }
             }
@@ -140,6 +143,18 @@ class MyPageFragment : Fragment() {
         startActivity(ManageAccountActivity.newIntent(requireContext()))
     }
 
+    private fun onClickLogoutDialog(){
+        val customDialog = LogoutDialog(logout = {onClickLogout()})
+        customDialog.show(parentFragmentManager, "CustomDialog")
+    }
+
+    private fun onClickLogout(){
+        requireActivity().apply {
+            finish()
+            startActivity(LoginActivity.newIntent(requireContext()))
+        }
+    }
+    
     private fun setLauncher() {
         updateNicknameLauncher =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->

--- a/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageFragment.kt
@@ -76,10 +76,10 @@ class MyPageFragment : Fragment() {
                 viewModel.event.collect { event ->
                     when (event) {
                         MyPageViewModel.Event.None -> {}
-                        is MyPageViewModel.Event.onClickUpdateNickname -> updateNicknameActivity(event.nickname)
-                        MyPageViewModel.Event.onClickWrittenReview -> writtenReviewActivity()
-                        MyPageViewModel.Event.onClickManageAccount -> manageAccountActivity()
-                        MyPageViewModel.Event.onClickLogout -> onClickLogoutDialog()
+                        is MyPageViewModel.Event.OnClickUpdateNickname -> updateNicknameActivity(event.nickname)
+                        MyPageViewModel.Event.OnClickWrittenReview -> writtenReviewActivity()
+                        MyPageViewModel.Event.OnClickManageAccount -> manageAccountActivity()
+                        MyPageViewModel.Event.OnClickLogout -> onClickLogoutDialog()
                     }
                 }
             }

--- a/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageFragment.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class MyPageFragment : Fragment() {
+class MyPageFragment : Fragment(), LogoutDialog.Listener {
 
     private lateinit var updateNicknameLauncher: ActivityResultLauncher<Intent>
 
@@ -144,11 +144,11 @@ class MyPageFragment : Fragment() {
     }
 
     private fun onClickLogoutDialog(){
-        val customDialog = LogoutDialog(logout = {onClickLogout()})
-        customDialog.show(parentFragmentManager, "CustomDialog")
+        val logoutDialog = LogoutDialog()
+        logoutDialog.show(childFragmentManager, "CustomDialog")
     }
 
-    private fun onClickLogout(){
+    override fun onClickLogoutFromLogoutDialog(){
         requireActivity().apply {
             finish()
             startActivity(LoginActivity.newIntent(requireContext()))

--- a/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageViewModel.kt
@@ -15,10 +15,10 @@ class MyPageViewModel (
 
     sealed class Event {
         object None : Event()
-        class onClickUpdateNickname(val nickname: String) : Event()
-        object onClickWrittenReview : Event()
-        object onClickManageAccount : Event()
-        object onClickLogout : Event()
+        class OnClickUpdateNickname(val nickname: String) : Event()
+        object OnClickWrittenReview : Event()
+        object OnClickManageAccount : Event()
+        object OnClickLogout : Event()
     }
 
     private val _user: MutableStateFlow<User> = MutableStateFlow(User.NONE)
@@ -42,22 +42,22 @@ class MyPageViewModel (
     }
 
     fun onClickUpdateNickname() {
-        _event.value = Event.onClickUpdateNickname(user.value.nickName)
+        _event.value = Event.OnClickUpdateNickname(user.value.nickName)
         _event.value = Event.None
     }
 
     fun onClickWrittenReview() {
-        _event.value = Event.onClickWrittenReview
+        _event.value = Event.OnClickWrittenReview
         _event.value = Event.None
     }
 
     fun onClickManageAccount() {
-        _event.value = Event.onClickManageAccount
+        _event.value = Event.OnClickManageAccount
         _event.value = Event.None
     }
 
     fun onClickLogout() {
-        _event.value = Event.onClickLogout
+        _event.value = Event.OnClickLogout
         _event.value = Event.None
     }
 }

--- a/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/main/mypage/MyPageViewModel.kt
@@ -18,6 +18,7 @@ class MyPageViewModel (
         class onClickUpdateNickname(val nickname: String) : Event()
         object onClickWrittenReview : Event()
         object onClickManageAccount : Event()
+        object onClickLogout : Event()
     }
 
     private val _user: MutableStateFlow<User> = MutableStateFlow(User.NONE)
@@ -52,6 +53,11 @@ class MyPageViewModel (
 
     fun onClickManageAccount() {
         _event.value = Event.onClickManageAccount
+        _event.value = Event.None
+    }
+
+    fun onClickLogout() {
+        _event.value = Event.onClickLogout
         _event.value = Event.None
     }
 }

--- a/app/src/main/java/com/ftw/hometerview/ui/updatenickname/UpdateNicknameActivity.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/updatenickname/UpdateNicknameActivity.kt
@@ -40,6 +40,7 @@ class UpdateNicknameActivity : AppCompatActivity() {
             this,
             R.layout.activity_update_nick_name
         ).apply {
+            lifecycleOwner = this@UpdateNicknameActivity
             viewModel = this@UpdateNicknameActivity.viewModel
         }
 
@@ -49,13 +50,6 @@ class UpdateNicknameActivity : AppCompatActivity() {
     }
 
     fun observe() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.nickname.collect {
-                    binding.lengthTextview.text = getString(R.string.written_nickname_length, it.length)
-                }
-            }
-        }
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.event.collect { event ->

--- a/app/src/main/java/com/ftw/hometerview/ui/withdrawal/WithdrawalActivity.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/withdrawal/WithdrawalActivity.kt
@@ -5,13 +5,9 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.ftw.hometerview.R
 import com.ftw.hometerview.databinding.ActivityWithdrawalBinding
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -34,18 +30,9 @@ class WithdrawalActivity : AppCompatActivity() {
             this,
             R.layout.activity_withdrawal
         ).apply {
+            lifecycleOwner = this@WithdrawalActivity
             viewModel = this@WithdrawalActivity.viewModel
         }
-        observe()
     }
 
-    private fun observe() {
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.withdrawalCheck.collect { showBanner ->
-                    binding.withdrawalButton.isEnabled = showBanner
-                }
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/ftw/hometerview/ui/withdrawal/WithdrawalViewModel.kt
+++ b/app/src/main/java/com/ftw/hometerview/ui/withdrawal/WithdrawalViewModel.kt
@@ -1,12 +1,6 @@
 package com.ftw.hometerview.ui.withdrawal
 
-import com.ftw.hometerview.BR
-import com.ftw.hometerview.R
-import com.ftw.hometerview.adapter.RecyclerItem
 import com.ftw.hometerview.dispatcher.Dispatcher
-import com.ftw.hometerview.ui.main.favorite.favoritelist.FavoriteBuildingItem
-import com.ftw.hometerview.ui.main.favorite.favoritelist.FavoriteBuildingsViewModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.*
 
 class WithdrawalViewModel(
@@ -17,6 +11,7 @@ class WithdrawalViewModel(
     val withdrawalSecondCheck: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val withdrawalThirdCheck: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val withdrawalCheck: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
 
     fun onClickWithdrawalFirstCheck() {
         withdrawalFirstCheck.value = !withdrawalFirstCheck.value

--- a/app/src/main/res/drawable/round_background_white.xml
+++ b/app/src/main/res/drawable/round_background_white.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#ffffff"/>
+    <corners android:radius="16dp"/>
+</shape>

--- a/app/src/main/res/drawable/round_background_white.xml
+++ b/app/src/main/res/drawable/round_background_white.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <solid android:color="#ffffff"/>
-    <corners android:radius="16dp"/>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle"
+    >
+    <solid android:color="@color/white" />
+    <corners android:radius="@dimen/dp_size_16" />
 </shape>

--- a/app/src/main/res/layout/activity_create_review.xml
+++ b/app/src/main/res/layout/activity_create_review.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
+
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragment_container_view"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_update_nick_name.xml
+++ b/app/src/main/res/layout/activity_update_nick_name.xml
@@ -52,13 +52,13 @@
             android:layout_height="wrap_content"
             android:fontFamily="@font/pretendard_regular"
             android:textSize="@dimen/sp_size_12"
+            android:text="@{@string/written_nickname_length(viewModel.nickname.length())}"
             android:textColor="@color/gray_400"
             android:layout_marginTop="@dimen/dp_size_8"
             app:layout_constraintEnd_toEndOf="@+id/nickname_edittext"
             app:layout_constraintTop_toBottomOf="@+id/nickname_edittext"
             tools:text="3/20 자"
             />
-
 
         <com.ftw.hometerview.design.MainButton
             android:id="@+id/update_nickname_button"

--- a/app/src/main/res/layout/dialog_logout.xml
+++ b/app/src/main/res/layout/dialog_logout.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/round_background_white"
+        >
+
+        <View
+            android:id="@+id/divide_vertical_view"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/dp_size_1"
+            android:background="@color/gray_300"
+            app:layout_constraintBottom_toTopOf="@+id/logout_cancle"
+            />
+
+        <View
+            android:id="@+id/divide_horizontal_view"
+            android:layout_width="@dimen/dp_size_1"
+            android:layout_height="0dp"
+            android:background="@color/gray_300"
+            android:layout_marginHorizontal="@dimen/dp_size_1"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/logout_select"
+            app:layout_constraintStart_toEndOf="@+id/logout_cancle"
+            app:layout_constraintTop_toBottomOf="@+id/divide_vertical_view"
+            />
+
+        <TextView
+            android:id="@+id/logout_select"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@drawable/round_background_white"
+            android:fontFamily="@font/pretendard_semibold"
+            android:gravity="center"
+            android:paddingVertical="@dimen/dp_size_16"
+            android:text="@string/logout_select_text"
+            android:textColor="@color/blue_300"
+            android:textSize="@dimen/sp_size_14"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toEndOf="@+id/divide_horizontal_view"
+            />
+
+        <TextView
+            android:id="@+id/logout_cancle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/pretendard_semibold"
+            android:gravity="center"
+            android:paddingVertical="@dimen/dp_size_16"
+            android:text="@string/logout_cancle_text"
+            android:textColor="@color/black"
+            android:textSize="@dimen/sp_size_14"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/divide_horizontal_view"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            />
+
+        <TextView
+            android:id="@+id/logout_ask_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/dp_size_48"
+            android:layout_marginBottom="@dimen/dp_size_48"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="@string/logout_ask_text"
+            android:textColor="@color/black"
+            android:textSize="@dimen/sp_size_16"
+            app:layout_constraintBottom_toTopOf="@+id/divide_vertical_view"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -306,6 +306,7 @@
                 android:id="@+id/logout_box"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:onClick="@{() -> viewModel.onClickLogout()}"
                 android:paddingVertical="@dimen/dp_size_16"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -135,5 +135,8 @@
     <string name="withdrawal_second_check_text">회원 탈퇴 후 재가입하더라도 탈퇴 전의 회원 정보 및 서비스 이용 기록은 복구되지 않습니다.</string>
     <string name="withdrawal_third_check_text">회원을 탈퇴하더라도 집터뷰 서비스에 기록한 리뷰, 댓글 등의 게시물은 삭제되지 않습니다. 회원을 퇄퇴하면, 개인정보가 삭제되며 게시물을 수정하거나 삭제할 수 없으니게시물 삭제가 필요한 회원은 게시물 삭제 후 탈퇴 신청하시기 바랍니다. </string>
 
+    <string name="logout_cancle_text">취소</string>
+    <string name="logout_ask_text">로그아웃 하시겠습니까?</string>
+    <string name="logout_select_text">확인</string>
 
 </resources>


### PR DESCRIPTION
### 1. 개요
로그아웃 다이얼로그를 구현했습니다.

### 2. 작업사항
* N/A

### 3. 변경로직
* N/A

### 4. 스크린샷
https://user-images.githubusercontent.com/54509842/187046607-57a88960-76fa-46e9-980a-bb5f1811544f.mp4

### 5. 참고링크
- [디자인](https://www.figma.com/file/VBtuKLaxlF1ZaKEXCh505b/hometerview?node-id=630%3A22731)

### 6. 기타
지난번에 데이터바인딩에서 생긴 문제점(액티비티에서 콜렉트를 해줘야만 했던 문제점)의 이유를 찾았습니다.
lifecycleowner를 설정해주면 해결되는 일이였습니다. 
같은 방식으로 [닉네임 변경화면에서 닉네임 제한 텍스트], [회원탈퇴 버튼의 활성화 여부]를 콜렉트 하던 코드를 삭제할 수 있었습니다.
<img src="https://user-images.githubusercontent.com/54509842/187046932-4120adba-b298-43d3-8bf6-88ddbe4da60a.png" width="500">

